### PR TITLE
Add concurrent multi-user test support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,18 +8,19 @@ from typing import Union
 
 import server
 from aiohttp import web
+from aiohttp.web_request import Request
 import folder_paths
 from folder_paths import models_dir
 
 
 @server.PromptServer.instance.routes.get("/devtools/fake_model.safetensors")
-async def fake_model(request):
+async def fake_model(request: Request):
     file_path = os.path.join(os.path.dirname(__file__), "fake_model.safetensors")
     return web.FileResponse(file_path)
 
 
 @server.PromptServer.instance.routes.get("/devtools/cleanup_fake_model")
-async def cleanup_fake_model(request):
+async def cleanup_fake_model(request: Request):
     model_folder = request.query.get("model_folder", "clip")
     model_path = os.path.join(models_dir, model_folder, "fake_model.safetensors")
     if os.path.exists(model_path):
@@ -54,7 +55,7 @@ def write_tree_structure(tree: TreeType, base_path: str):
 
 
 @server.PromptServer.instance.routes.post("/devtools/setup_folder_structure")
-async def setup_folder_structure(request):
+async def setup_folder_structure(request: Request):
     try:
         data = await request.json()
         tree_structure = data.get("tree_structure")
@@ -74,7 +75,7 @@ async def setup_folder_structure(request):
 
 
 @server.PromptServer.instance.routes.post("/devtools/set_settings")
-async def set_settings(request):
+async def set_settings(request: Request):
     """Directly set the settings for the default user, instead of merging with
     the existing settings."""
     try:

--- a/__init__.py
+++ b/__init__.py
@@ -76,12 +76,16 @@ async def setup_folder_structure(request: Request):
 
 @server.PromptServer.instance.routes.post("/devtools/set_settings")
 async def set_settings(request: Request):
-    """Directly set the settings for the default user, instead of merging with
-    the existing settings."""
+    """Directly set the settings for the user specified via `Comfy.userId`,
+    instead of merging with the existing settings."""
     try:
-        settings = await request.json()
+        settings: dict[str, str | bool | int | float] = await request.json()
         user_root = folder_paths.get_user_directory()
-        settings_file_path = os.path.join(user_root, "default", "comfy.settings.json")
+        try:
+            user_id: str = settings.pop("Comfy.userId")
+        except KeyError:
+            user_id = "default"
+        settings_file_path = os.path.join(user_root, user_id, "comfy.settings.json")
 
         # Ensure the directory structure exists
         os.makedirs(os.path.dirname(settings_file_path), exist_ok=True)


### PR DESCRIPTION
Allows `set_settings` API caller to specify their `Comfy.userId`.