### PR TITLE
Decrease number of options in test node with 1,000,000 options

### DIFF
--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -65,7 +65,7 @@ class DeprecatedNode:
 class LongComboDropdown:
     @classmethod
     def INPUT_TYPES(cls):
-        return {"required": {"option": ([f"Option {i}" for i in range(1000 * 1000)],)}}
+        return {"required": {"option": ([f"Option {i}" for i in range(1_000)],)}}
 
     RETURN_TYPES = ()
     OUTPUT_NODE = True


### PR DESCRIPTION
The node with 1 million dropdown options is causing 17.1 MB `object_info` response which affects test performance.

![Selection_676](https://github.com/user-attachments/assets/a7d1a1a4-3d3d-4687-988d-8a9ebdfc34b9)
