### PR TITLE
Update public API syntax of nodes with remote COMBO inputs

### DIFF
--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -321,8 +321,9 @@ class RemoteWidgetNode:
                 "remote_widget_value": (
                     "COMBO",
                     {
-                        "type": "remote",
-                        "route": "/api/models/checkpoints",
+                        "remote": {
+                            "route": "/api/models/checkpoints",
+                        },
                     },
                 ),
             },
@@ -345,10 +346,11 @@ class RemoteWidgetNodeWithParams:
                 "remote_widget_value": (
                     "COMBO",
                     {
-                        "type": "remote",
-                        "route": "/api/models/checkpoints",
-                        "query_params": {
-                            "sort": "true",
+                        "remote": {
+                            "route": "/api/models/checkpoints",
+                            "query_params": {
+                                "sort": "true",
+                            },
                         },
                     },
                 ),
@@ -374,9 +376,10 @@ class RemoteWidgetNodeWithRefresh:
                 "remote_widget_value": (
                     "COMBO",
                     {
-                        "type": "remote",
-                        "route": "/api/models/checkpoints",
-                        "refresh": 300,
+                        "remote": {
+                            "route": "/api/models/checkpoints",
+                            "refresh": 300,
+                        },
                     },
                 ),
             },


### PR DESCRIPTION
Updates the public API syntax of nodes with remote COMBO inputs. The `type` property already exists on [`BaseInputSpec`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/3d59d478b6ddab42251eba51af39e171d7b1e22a/src/stores/nodeDefStore.ts#L24-L31), causing the `type` property on the node class to be shadowed when transformed to `ComfyNodeDefImpl`, potentially causing issues in the future.

```diff
class RemoteWidgetNode:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {
                "remote_widget_value": (
                    "COMBO",
                    {
-                        "type": "remote",
-                        "route": "/api/models/checkpoints",
+                        "remote": {
+                            "route": "/api/models/checkpoints",
+                        },
                    },
                ),
            },
        }
```