### PR TITLE
Add test nodes for remote widgets with refresh button 

### DIFF
--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -404,7 +404,7 @@ class RemoteWidgetNodeWithRefreshButton:
                     {
                         "remote": {
                             "route": "/api/models/checkpoints",
-                            "refresh_button": "true",
+                            "refresh_button": True,
                         },
                     },
                 ),
@@ -430,7 +430,7 @@ class RemoteWidgetWithControlAfterRefresh:
                     {
                         "remote": {
                             "route": "/api/models/checkpoints",
-                            "refresh_button": "true",
+                            "refresh_button": True,
                             "control_after_refresh": "first",
                         },
                     },

--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -420,7 +420,7 @@ class RemoteWidgetNodeWithRefreshButton:
         return (remote_widget_value,)
 
 
-class RemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh:
+class RemoteWidgetWithSelectOnRefresh:
     @classmethod
     def INPUT_TYPES(cls):
         return {
@@ -431,7 +431,7 @@ class RemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh:
                         "remote": {
                             "route": "/api/models/checkpoints",
                             "refresh_button": "true",
-                            "select_on_refresh": "true",
+                            "select_on_refresh": "first",
                         },
                     },
                 ),
@@ -467,7 +467,7 @@ NODE_CLASS_MAPPINGS = {
     "DevToolsRemoteWidgetNodeWithParams": RemoteWidgetNodeWithParams,
     "DevToolsRemoteWidgetNodeWithRefresh": RemoteWidgetNodeWithRefresh,
     "DevToolsRemoteWidgetNodeWithRefreshButton": RemoteWidgetNodeWithRefreshButton,
-    "DevToolsRemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh": RemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh,
+    "DevToolsRemoteWidgetSelectOnRefresh": RemoteWidgetWithSelectOnRefresh,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {

--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -295,8 +295,8 @@ class ObjectPatchNode:
                 "target_module": ("STRING", {"multiline": True}),
             },
             "optional": {
-                "dummy_float": ("FLOAT", {"default": 0.0 }),
-            }
+                "dummy_float": ("FLOAT", {"default": 0.0}),
+            },
         }
 
     RETURN_TYPES = ("MODEL",)
@@ -394,6 +394,59 @@ class RemoteWidgetNodeWithRefresh:
         return (remote_widget_value,)
 
 
+class RemoteWidgetNodeWithRefreshButton:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "remote_widget_value": (
+                    "COMBO",
+                    {
+                        "remote": {
+                            "route": "/api/models/checkpoints",
+                            "refresh_button": "true",
+                        },
+                    },
+                ),
+            },
+        }
+
+    FUNCTION = "remote_widget"
+    CATEGORY = "DevTools"
+    DESCRIPTION = "A node that lazily fetches options from a remote endpoint and has a refresh button to manually reload options"
+    RETURN_TYPES = ("STRING",)
+
+    def remote_widget(self, remote_widget_value: str):
+        return (remote_widget_value,)
+
+
+class RemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "remote_widget_value": (
+                    "COMBO",
+                    {
+                        "remote": {
+                            "route": "/api/models/checkpoints",
+                            "refresh_button": "true",
+                            "select_on_refresh": "true",
+                        },
+                    },
+                ),
+            },
+        }
+
+    FUNCTION = "remote_widget"
+    CATEGORY = "DevTools"
+    DESCRIPTION = "A node that lazily fetches options from a remote endpoint and has a refresh button to manually reload options and select the first option on refresh"
+    RETURN_TYPES = ("STRING",)
+
+    def remote_widget(self, remote_widget_value: str):
+        return (remote_widget_value,)
+
+
 NODE_CLASS_MAPPINGS = {
     "DevToolsErrorRaiseNode": ErrorRaiseNode,
     "DevToolsErrorRaiseNodeWithMessage": ErrorRaiseNodeWithMessage,
@@ -413,6 +466,8 @@ NODE_CLASS_MAPPINGS = {
     "DevToolsRemoteWidgetNode": RemoteWidgetNode,
     "DevToolsRemoteWidgetNodeWithParams": RemoteWidgetNodeWithParams,
     "DevToolsRemoteWidgetNodeWithRefresh": RemoteWidgetNodeWithRefresh,
+    "DevToolsRemoteWidgetNodeWithRefreshButton": RemoteWidgetNodeWithRefreshButton,
+    "DevToolsRemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh": RemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -434,4 +489,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "DevToolsRemoteWidgetNode": "Remote Widget Node",
     "DevToolsRemoteWidgetNodeWithParams": "Remote Widget Node With Sort Query Param",
     "DevToolsRemoteWidgetNodeWithRefresh": "Remote Widget Node With 300ms Refresh",
+    "DevToolsRemoteWidgetNodeWithRefreshButton": "Remote Widget Node With Refresh Button",
+    "DevToolsRemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh": "Remote Widget Node With Refresh Button And Select On Refresh",
 }

--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -420,7 +420,7 @@ class RemoteWidgetNodeWithRefreshButton:
         return (remote_widget_value,)
 
 
-class RemoteWidgetWithControlAfterRefresh:
+class RemoteWidgetNodeWithControlAfterRefresh:
     @classmethod
     def INPUT_TYPES(cls):
         return {
@@ -467,7 +467,7 @@ NODE_CLASS_MAPPINGS = {
     "DevToolsRemoteWidgetNodeWithParams": RemoteWidgetNodeWithParams,
     "DevToolsRemoteWidgetNodeWithRefresh": RemoteWidgetNodeWithRefresh,
     "DevToolsRemoteWidgetNodeWithRefreshButton": RemoteWidgetNodeWithRefreshButton,
-    "DevToolsRemoteWidgetSelectOnRefresh": RemoteWidgetWithControlAfterRefresh,
+    "DevToolsRemoteWidgetNodeWithControlAfterRefresh": RemoteWidgetNodeWithControlAfterRefresh,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -490,5 +490,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "DevToolsRemoteWidgetNodeWithParams": "Remote Widget Node With Sort Query Param",
     "DevToolsRemoteWidgetNodeWithRefresh": "Remote Widget Node With 300ms Refresh",
     "DevToolsRemoteWidgetNodeWithRefreshButton": "Remote Widget Node With Refresh Button",
-    "DevToolsRemoteWidgetNodeWithRefreshButtonAndSelectOnRefresh": "Remote Widget Node With Refresh Button And Select On Refresh",
+    "DevToolsRemoteWidgetNodeWithControlAfterRefresh": "Remote Widget Node With Refresh Button and Control After Refresh",
 }

--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -420,7 +420,7 @@ class RemoteWidgetNodeWithRefreshButton:
         return (remote_widget_value,)
 
 
-class RemoteWidgetWithSelectOnRefresh:
+class RemoteWidgetWithControlAfterRefresh:
     @classmethod
     def INPUT_TYPES(cls):
         return {
@@ -431,7 +431,7 @@ class RemoteWidgetWithSelectOnRefresh:
                         "remote": {
                             "route": "/api/models/checkpoints",
                             "refresh_button": "true",
-                            "select_on_refresh": "first",
+                            "control_after_refresh": "first",
                         },
                     },
                 ),
@@ -467,7 +467,7 @@ NODE_CLASS_MAPPINGS = {
     "DevToolsRemoteWidgetNodeWithParams": RemoteWidgetNodeWithParams,
     "DevToolsRemoteWidgetNodeWithRefresh": RemoteWidgetNodeWithRefresh,
     "DevToolsRemoteWidgetNodeWithRefreshButton": RemoteWidgetNodeWithRefreshButton,
-    "DevToolsRemoteWidgetSelectOnRefresh": RemoteWidgetWithSelectOnRefresh,
+    "DevToolsRemoteWidgetSelectOnRefresh": RemoteWidgetWithControlAfterRefresh,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {


### PR DESCRIPTION
Adds nodes for testing remote widgets with refresh button options, and `control_after_refresh` (using same naming pattern as `control_before_generate`), which adds optional behavior to force a selection after combo options are refreshed.

```python
class LoadImageOutputRefresh(LoadImage):
    @classmethod
    def INPUT_TYPES(s):
        return {
            "required": {
                "image": (
                    "COMBO",
                    {
                        "image_upload": True,
                        "image_folder": "output",
                        "remote": {
                            "route": "/internal/files/output",
                            "refresh_button": True,
                            "control_after_refresh": "first",
                        },
                    },
                )
            },
        }

    @classmethod
    def VALIDATE_INPUTS(s, image):
        return True

    CATEGORY = "image"
    RETURN_TYPES = ("IMAGE", "MASK")
    FUNCTION = "load_image_output"

    def load_image_output(self, image):
        return self.load_image(f"{image} [output]")
```