### PR TITLE
Add max_retries and timeout fields to remote widget nodes

### DIFF
--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -379,6 +379,8 @@ class RemoteWidgetNodeWithRefresh:
                         "remote": {
                             "route": "/api/models/checkpoints",
                             "refresh": 300,
+                            "max_retries": 10,
+                            "timeout": 256,
                         },
                     },
                 ),


### PR DESCRIPTION
Lowers the timeout and increases max retries for nodes in order to not have to wait long periods during browser testing.