### PR TITLE
fix(devtools): add RETURN_TYPES to RemoteWidgetNodeWithControlAfterRe…

### DIFF
--- a/dev_nodes.py
+++ b/dev_nodes.py
@@ -522,6 +522,7 @@ class RemoteWidgetNodeWithControlAfterRefresh:
             },
         }
 
+    RETURN_TYPES = ("STRING",)
     FUNCTION = "remote_widget"
     CATEGORY = "DevTools"
     DESCRIPTION = "A node that fetches options and selects the first option after a manual refresh"
@@ -545,8 +546,8 @@ class NodeWithOutputCombo:
     CATEGORY = "DevTools"
     DESCRIPTION = "A node that outputs a combo type"
 
-    def node_with_output_combo(self, subset_options: str):
-        return (subset_options,)
+    def node_with_output_combo(self, subset_options: str, subset_options_v2: str):
+        return (subset_options_v2 or subset_options)
 
 
 class MultiSelectNode:
@@ -568,7 +569,7 @@ class MultiSelectNode:
         }
 
     RETURN_TYPES = ("STRING",)
-    OUTPUT_IS_LIST = [True]
+    OUTPUT_IS_LIST = (True,)
     FUNCTION = "multi_select_node"
     CATEGORY = "DevTools"
     DESCRIPTION = "A node that outputs a multi select type"


### PR DESCRIPTION
fix(devtools): add RETURN_TYPES to RemoteWidgetNodeWithControlAfterRefresh; accept both inputs in NodeWithOutputCombo

- Add class-level RETURN_TYPES required by ComfyUI introspection
- Update NodeWithOutputCombo signature to accept subset_options_v2 and prefer it when present
- made OUTPUT_IS_LIST a tuple for consistency
